### PR TITLE
입찰 생성, 거래 성사 시 락 사용

### DIFF
--- a/src/main/java/kr/flab/fream/domain/auction/AuctionLockManager.java
+++ b/src/main/java/kr/flab/fream/domain/auction/AuctionLockManager.java
@@ -1,0 +1,26 @@
+package kr.flab.fream.domain.auction;
+
+import kr.flab.fream.mybatis.mapper.auction.AuctionLockByProductIdAndSizeIdMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 입찰 생성, 입찰 성사 시 별도의 테이블을 사용하여 락 기능을 제공한다.
+ *
+ * @since 1.0.1
+ */
+@Component
+@RequiredArgsConstructor
+@Transactional(propagation = Propagation.MANDATORY)
+public class AuctionLockManager {
+
+    private final AuctionLockByProductIdAndSizeIdMapper lockMapper;
+
+    public void lock(Long productId, Long sizeId) {
+        lockMapper.tryInsertRecord(productId, sizeId);
+        lockMapper.getLock(productId, sizeId);
+    }
+
+}

--- a/src/main/java/kr/flab/fream/domain/auction/model/Auction.java
+++ b/src/main/java/kr/flab/fream/domain/auction/model/Auction.java
@@ -87,7 +87,7 @@ public class Auction {
      * 입찰 완료 처리한다.
      */
     public void sign(User bidder) {
-        if (Objects.equals(this.user.getId(), bidder.getId())) {
+        if (Objects.equals(this.getUser().getId(), bidder.getId())) {
             throw new IllegalArgumentException("직접 등록한 입찰에 참여할 수 없습니다.");
         }
         state.finish(this);

--- a/src/main/java/kr/flab/fream/mybatis/mapper/auction/AuctionLockByProductIdAndSizeIdMapper.java
+++ b/src/main/java/kr/flab/fream/mybatis/mapper/auction/AuctionLockByProductIdAndSizeIdMapper.java
@@ -1,0 +1,19 @@
+package kr.flab.fream.mybatis.mapper.auction;
+
+import org.apache.ibatis.annotations.Mapper;
+
+/**
+ * 입찰 생성, 거래 성사 시 사용할 락 테이블을 조작하는 mapper.
+ * <br>
+ * productId, sizeId 기준으로 락을 건다.
+ *
+ * @since 1.0.1
+ */
+@Mapper
+public interface AuctionLockByProductIdAndSizeIdMapper {
+
+    void tryInsertRecord(Long productId, Long sizeId);
+
+    void getLock(Long productId, Long sizeId);
+
+}

--- a/src/main/resources/db/migration/V1.0.1__Auction_lock_table.sql
+++ b/src/main/resources/db/migration/V1.0.1__Auction_lock_table.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS auction_lock_by_product_id_and_size_id
+(
+    product_id  BIGINT         NOT NULL,
+    size_id     BIGINT         NOT NULL,
+
+    constraint auction_lock_by_product_id_and_size_id_pk
+        primary key (product_id, size_id)
+);

--- a/src/main/resources/kr/flab/fream/mybatis/mapper/auction/AuctionLockByProductIdAndSizeIdMapper.xml
+++ b/src/main/resources/kr/flab/fream/mybatis/mapper/auction/AuctionLockByProductIdAndSizeIdMapper.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+    PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+    "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="kr.flab.fream.mybatis.mapper.auction.AuctionLockByProductIdAndSizeIdMapper">
+
+  <insert id="tryInsertRecord">
+    INSERT IGNORE INTO auction_lock_by_product_id_and_size_id
+    VALUES (#{productId}, #{sizeId})
+  </insert>
+
+  <select id="getLock" resultType="int">
+    SELECT COUNT(*) FROM auction_lock_by_product_id_and_size_id
+    WHERE product_id = #{productId}
+        AND size_id = #{sizeId}
+    FOR UPDATE
+  </select>
+
+</mapper>

--- a/src/test/groovy/kr/flab/fream/domain/auction/service/AuctionServiceIntegrationSpec.groovy
+++ b/src/test/groovy/kr/flab/fream/domain/auction/service/AuctionServiceIntegrationSpec.groovy
@@ -1,32 +1,15 @@
 package kr.flab.fream.domain.auction.service
 
-import kr.flab.domain.auction.AuctionFixtures
-import kr.flab.domain.product.ProductFixtures
-import kr.flab.fream.DatabaseClearConfig
-import kr.flab.fream.DatabaseTest
+
 import kr.flab.fream.IntegrationSpec
-import kr.flab.fream.config.ModelMapperConfiguration
-import kr.flab.fream.controller.auction.AuctionDto
-import kr.flab.fream.controller.auction.AuctionPatchRequest
 import kr.flab.fream.controller.auction.AuctionRequest
 import kr.flab.fream.controller.auction.AuctionSummaryByPriceAndSizeWithQuantity
-import kr.flab.fream.domain.auction.AuctionSearchOption
-import kr.flab.fream.domain.auction.dto.SignAuctionResponse
-import kr.flab.fream.domain.auction.model.Ask
 import kr.flab.fream.domain.auction.model.AuctionType
-import kr.flab.fream.domain.product.model.Product
-import kr.flab.fream.domain.product.service.ProductService
-import kr.flab.fream.domain.user.model.User
 import kr.flab.fream.mybatis.mapper.auction.AuctionMapper
 import kr.flab.fream.mybatis.mapper.user.UserMapper
 import org.modelmapper.ModelMapper
-import org.spockframework.spring.SpringBean
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.context.annotation.Import
 import org.springframework.test.context.jdbc.Sql
-import org.springframework.transaction.annotation.Transactional
 
 import static org.assertj.core.api.Assertions.assertThat
 
@@ -40,6 +23,9 @@ class AuctionServiceIntegrationSpec extends IntegrationSpec {
 
     @Autowired
     AuctionService sut
+
+    @Autowired
+    UserMapper userMapper
 
     @Sql("/db-test-data/auction/get-ask-summaries.sql")
     def "get ASK summaries"() {
@@ -102,6 +88,36 @@ class AuctionServiceIntegrationSpec extends IntegrationSpec {
                 new AuctionSummaryByPriceAndSizeWithQuantity("265", new BigDecimal("495000.00"), 1, AuctionType.BID),
             ),
         ]
+    }
+
+    def "create an auction"() {
+        given:
+        def request = new AuctionRequest(
+            new BigDecimal("100000"),
+            1,
+            1,
+            1,
+            30,
+             AuctionType.ASK
+        )
+
+        when:
+        def response = sut.createAuction(request)
+
+        then:
+        response != null
+    }
+
+    def "sign an auction"() {
+        given:
+        def user = userMapper.getUserById(2)
+        def auctionId = 1L
+
+        when:
+        def response = sut.sign(user, auctionId)
+
+        then:
+        response != null
     }
 
 }

--- a/src/test/groovy/kr/flab/fream/domain/auction/service/AuctionServiceSpec.groovy
+++ b/src/test/groovy/kr/flab/fream/domain/auction/service/AuctionServiceSpec.groovy
@@ -5,6 +5,7 @@ import kr.flab.domain.product.ProductFixtures
 import kr.flab.fream.config.ModelMapperConfiguration
 import kr.flab.fream.controller.auction.AuctionPatchRequest
 import kr.flab.fream.controller.auction.AuctionRequest
+import kr.flab.fream.domain.auction.AuctionLockManager
 import kr.flab.fream.domain.auction.AuctionSearchOption
 import kr.flab.fream.domain.auction.dto.SignAuctionResponse
 import kr.flab.fream.domain.auction.model.Ask
@@ -36,6 +37,8 @@ class AuctionServiceSpec extends Specification {
 
     ModelMapper modelMapper = new ModelMapperConfiguration().modelMapper()
 
+    AuctionLockManager lockManager
+
     AuctionService sut
 
     void setup() {
@@ -47,7 +50,9 @@ class AuctionServiceSpec extends Specification {
 
         auctionMapper = Stub()
 
-        sut = new AuctionService(auctionMapper, userMapper, productService, modelMapper)
+        lockManager = Stub()
+
+        sut = new AuctionService(auctionMapper, userMapper, productService, modelMapper, lockManager)
     }
 
     def "throw IllegalArgumentException if product does not have a given size"() {
@@ -87,6 +92,7 @@ class AuctionServiceSpec extends Specification {
         def targetAuction = auction()
         def auctionId = targetAuction.getId()
 
+        auctionMapper.getAuction(auctionId) >> targetAuction
         auctionMapper.getAuctionForUpdate(auctionId) >> targetAuction
 
         when:
@@ -152,6 +158,7 @@ class AuctionServiceSpec extends Specification {
 
         auction.user = UserFixtures.firstUser()
         auction.product = targetProduct
+        auction.size = targetProduct.sizes.sizeList[0]
 
         return auction
     }


### PR DESCRIPTION
### Description

Kream 앱에는 다음과 같은 제약조건이 있다.

> - 구매 입찰(Bid)을 등록할 때, 판매 입찰(Ask)의 최저가보다 높은 금액으로 등록할 수 없다.
> - 판매 입찰(Ask)을 등록할 때, 구매 입찰(Bid)의 최고가보다 낮은 금액으로 등록할 수 없다.

ASK, BID가 동시에 생성되는 경우와, 즉시 구매, 즉시 판매와 입찰 생성이 동시에 이뤄지는 경우에 위의 조건을 만족할 수 없을 수 있다.

무결성을 지키기 위해 입찰 생성과 즉시 거래가 이뤄지는 요청에 락을 사용하여 이러한 상황을 방지하도록 한다.

---

참고: [블로그 포스트](https://blog.cocahack.me/posts/27)